### PR TITLE
Twig 3 Compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.2.5",
         "symfony/framework-bundle": "^4.4",
         "symfony/security": "^4.4",
-        "twig/twig": "^2.0"
+        "twig/twig": "^2.0|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": ">4",


### PR DESCRIPTION
* allow twig 3
* php needs to be at least 7.2.5 now, because of twig 3. this will unfortunately require a new mayor release

