### PR TITLE
Remove deprecated usages of templating and replace them with twig

### DIFF
--- a/src/InterNations/Grid/Grid.php
+++ b/src/InterNations/Grid/Grid.php
@@ -565,7 +565,7 @@ class Grid
         if (!$view) {
             return $parameters;
         } else {
-            $response = $response ?? new Response();
+            $response ??= new Response();
             $response->setContent($this->container->get('twig')->render($view, $parameters));
             return $response;
         }

--- a/src/InterNations/Grid/Grid.php
+++ b/src/InterNations/Grid/Grid.php
@@ -565,7 +565,9 @@ class Grid
         if (!$view) {
             return $parameters;
         } else {
-            return $this->container->get('templating')->renderResponse($view, $parameters, $response);
+            $response = new Response();
+            $response->setContent($this->container->get('twig')->render($view, $parameters));
+            return $response;
         }
     }
 

--- a/src/InterNations/Grid/Grid.php
+++ b/src/InterNations/Grid/Grid.php
@@ -565,7 +565,7 @@ class Grid
         if (!$view) {
             return $parameters;
         } else {
-            $response = new Response();
+            $response = $response ?? new Response();
             $response->setContent($this->container->get('twig')->render($view, $parameters));
             return $response;
         }

--- a/src/InterNations/Grid/GridManager.php
+++ b/src/InterNations/Grid/GridManager.php
@@ -12,7 +12,6 @@
 namespace InterNations\DataGridBundle\Grid;
 
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Response;
 
 class GridManager implements \IteratorAggregate, \Countable
 {
@@ -107,7 +106,7 @@ class GridManager implements \IteratorAggregate, \Countable
                 return $parameters;
             }
             else {
-                $response = new Response();
+                $response = $response ?? new Response();
                 $response->setContent($this->container->get('twig')->render($view, $parameters));
                 return $response;
             }

--- a/src/InterNations/Grid/GridManager.php
+++ b/src/InterNations/Grid/GridManager.php
@@ -106,7 +106,7 @@ class GridManager implements \IteratorAggregate, \Countable
                 return $parameters;
             }
             else {
-                $response = $response ?? new Response();
+                $response ??= new Response();
                 $response->setContent($this->container->get('twig')->render($view, $parameters));
                 return $response;
             }

--- a/src/InterNations/Grid/GridManager.php
+++ b/src/InterNations/Grid/GridManager.php
@@ -12,6 +12,7 @@
 namespace InterNations\DataGridBundle\Grid;
 
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 class GridManager implements \IteratorAggregate, \Countable
 {
@@ -106,7 +107,9 @@ class GridManager implements \IteratorAggregate, \Countable
                 return $parameters;
             }
             else {
-                return $this->container->get('templating')->renderResponse($view, $parameters, $response);
+                $response = new Response();
+                $response->setContent($this->container->get('twig')->render($view, $parameters));
+                return $response;
             }
         }
     }


### PR DESCRIPTION
container->get('templating') is deprecated, so we replace it here with twig.
Nonetheless the renderResponse function is not available in twig, so I had to instantiate a response and set the content instead.